### PR TITLE
Add some MS Windows compatility for checking for executables

### DIFF
--- a/split_audiobook.py
+++ b/split_audiobook.py
@@ -91,7 +91,10 @@ def test_ff():
 
 
 def test_exe(name):
-    for p in os.environ.get("PATH", "").split(":"):
+    import sys 
+    if sys.platform == "win32" and not name.endswith(".exe"): 
+        name += ".exe"
+    for p in os.environ.get("PATH", "").split(os.pathsep):
         exe = os.path.join(p, name)
         if os.access(exe, os.X_OK):
             return True


### PR DESCRIPTION
MS Windows uses a different PATH separator. Also, executable files should have an extension ".exe" or ".com". This fix makes checking for ffmpeg(.exe) and ffprobe(.exe) compatible with MS Windows (and DOS).